### PR TITLE
Fixed CaseRequest.Get Method that always return null Data

### DIFF
--- a/src/HighriseApi/HighriseApi.csproj
+++ b/src/HighriseApi/HighriseApi.csproj
@@ -62,7 +62,7 @@
     <Compile Include="Models\Account.cs" />
     <Compile Include="Models\Address.cs" />
     <Compile Include="Models\BaseModel.cs" />
-    <Compile Include="Models\Case.cs" />
+    <Compile Include="Models\Kase.cs" />
     <Compile Include="Models\Comment.cs" />
     <Compile Include="Models\Enums\CommentType.cs" />
     <Compile Include="Models\SubjectField.cs" />

--- a/src/HighriseApi/Interfaces/ICaseRequest.cs
+++ b/src/HighriseApi/Interfaces/ICaseRequest.cs
@@ -10,28 +10,28 @@ namespace HighriseApi.Interfaces
         /// Gets a case by case ID.
         /// </summary>
         /// <returns>An instance of a <see cref="Case"/> object</returns>
-        Case Get(int id);
+        Kase Get(int id);
 
         /// <summary>
         /// Gets an IEnumerable collection of <see cref="Case"/> objects by <see cref="CaseStatus"/>.
         /// </summary>
         /// <param name="caseStatus">A <see cref="CaseStatus"/> enum value</param>
         /// <returns>An IEnumerable collection of <see cref="Case"/> objects</returns>.
-        IEnumerable<Case> Get(CaseStatus caseStatus);
+        IEnumerable<Kase> Get(CaseStatus caseStatus);
 
         /// <summary>
         /// Creates a new case
         /// </summary>
         /// <param name="kase">A <see cref="Case"/> object</param>
         /// <returns>A <see cref="Case"/> object, populated with new Highrise ID and CreatedAt/UpdatedAt values</returns>
-        Case Create(Case kase);
+        Kase Create(Kase kase);
 
         /// <summary>
         /// Updates a case
         /// </summary>
         /// <param name="kase">A <see cref="Case"/> object</param>
         /// <returns>True if successfully updated, otherwise false</returns>
-        bool Update(Case kase);
+        bool Update(Kase kase);
 
         /// <summary>
         /// Deletes a case

--- a/src/HighriseApi/Models/Kase.cs
+++ b/src/HighriseApi/Models/Kase.cs
@@ -11,7 +11,7 @@ using RestSharp.Serializers;
 namespace HighriseApi.Models
 {
     [SerializeAs(Name = "kase")]
-    public class Case : BaseModel
+    public class Kase : BaseModel
     {
         [SerializeAs(Name = "author-id")]
         public int AuthorId { get; set; }

--- a/src/HighriseApi/Requests/CaseRequest.cs
+++ b/src/HighriseApi/Requests/CaseRequest.cs
@@ -13,9 +13,9 @@ namespace HighriseApi.Requests
     {
         public CaseRequest(IRestClient client) : base(client) { }
 
-        public Case Get(int id)
+        public Kase Get(int id)
         {
-            var response = _client.Execute<Case>(new RestRequest(String.Format("kases/{0}.xml", id), Method.GET));
+            var response = _client.Execute<Kase>(new RestRequest(String.Format("kases/{0}.xml", id), Method.GET));
             var kase = response.Data;
 
             if (kase == null) return null;
@@ -24,11 +24,10 @@ namespace HighriseApi.Requests
             return kase;
         }
 
-        //TODO: Debug this method. response.Data is always null.
-        public IEnumerable<Case> Get(CaseStatus caseStatus)
+        public IEnumerable<Kase> Get(CaseStatus caseStatus)
         {
             var url = caseStatus == CaseStatus.Open ? "kases/open.xml" : "kases/closed.xml";
-            var response = _client.Execute<List<Case>>(new RestRequest(url, Method.GET));
+            var response = _client.Execute<List<Kase>>(new RestRequest(url, Method.GET));
             var kases = response.Data;
 
             foreach (var kase in kases)
@@ -37,28 +36,28 @@ namespace HighriseApi.Requests
             return kases;
         }
 
-        public Case Create(Case kase)
+        public Kase Create(Kase kase)
         {
             var request = new RestRequest("kases.xml", Method.POST) { XmlSerializer = new XmlIgnoreSerializer() };
             request.AddBody(kase);
 
-            var response = _client.Execute<Case>(request);
+            var response = _client.Execute<Kase>(request);
             return response.Data;
         }
 
-        public bool Update(Case kase)
+        public bool Update(Kase kase)
         {
             var request = new RestRequest("kases/{id}.xml", Method.PUT) { XmlSerializer = new XmlIgnoreSerializer() };
             request.AddParameter("id", kase.Id, ParameterType.UrlSegment);
             request.AddBody(kase);
 
-            var response = _client.Execute<Case>(request);
+            var response = _client.Execute<Kase>(request);
             return response.StatusCode == HttpStatusCode.OK;
         }
 
         public bool Delete(int id)
         {
-            var response = _client.Execute<Case>(new RestRequest(String.Format("kases/{0}.xml", id), Method.DELETE));
+            var response = _client.Execute<Kase>(new RestRequest(String.Format("kases/{0}.xml", id), Method.DELETE));
             return response.StatusCode == HttpStatusCode.OK;
         }
     }

--- a/src/HighriseApi/Requests/CommentRequest.cs
+++ b/src/HighriseApi/Requests/CommentRequest.cs
@@ -44,13 +44,13 @@ namespace HighriseApi.Requests
             request.AddParameter("id", comment.Id, ParameterType.UrlSegment);
             request.AddBody(comment);
 
-            var response = _client.Execute<Case>(request);
+            var response = _client.Execute<Kase>(request);
             return response.StatusCode == HttpStatusCode.OK;
         }
 
         public bool Delete(int id)
         {
-            var response = _client.Execute<Case>(new RestRequest(String.Format("comments/{0}.xml", id), Method.DELETE));
+            var response = _client.Execute<Kase>(new RestRequest(String.Format("comments/{0}.xml", id), Method.DELETE));
             return response.StatusCode == HttpStatusCode.OK;
         }
     }

--- a/src/HighriseApi/Requests/SubjectFieldRequest.cs
+++ b/src/HighriseApi/Requests/SubjectFieldRequest.cs
@@ -35,13 +35,13 @@ namespace HighriseApi.Requests
             request.AddParameter("id", subjectField.Id, ParameterType.UrlSegment);
             request.AddBody(subjectField);
 
-            var response = _client.Execute<Case>(request);
+            var response = _client.Execute<Kase>(request);
             return response.StatusCode == HttpStatusCode.OK;
         }
 
         public bool Delete(int id)
         {
-            var response = _client.Execute<Case>(new RestRequest(String.Format("subject_fields/{0}.xml", id), Method.DELETE));
+            var response = _client.Execute<Kase>(new RestRequest(String.Format("subject_fields/{0}.xml", id), Method.DELETE));
             return response.StatusCode == HttpStatusCode.OK;
         }
     }


### PR DESCRIPTION
Renamed Case to Kase, RestSharp could not resolve the type - 'case' is a
reserved word.
