### PR TITLE
Update Kase model definition

### DIFF
--- a/src/HighriseApi/Models/Enums/Frame.cs
+++ b/src/HighriseApi/Models/Enums/Frame.cs
@@ -14,6 +14,6 @@ namespace HighriseApi.Models.Enums
         next_week,
         later,
         specific,
-		overdue
+	overdue
     }
 }


### PR DESCRIPTION
It looks like Highrise allows author-id to be null is some cases.  If a case is returned with a null author id, the Case Request would fail.  This update will fix this issue.
